### PR TITLE
feat: add AsyncHotmart client for native async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,21 @@ This SDK handles OAuth, token refresh, retries, rate limits, and pagination auto
 
 ## Features
 
+- **Sync and async clients** — `Hotmart` for synchronous code, `AsyncHotmart` for `asyncio`/`async`-first frameworks (FastAPI, aiohttp, etc.). Identical API surface, full feature parity.
 - **Fully typed responses** — every API response is a Pydantic v2 model. Your IDE completes field names; no raw dicts, no guessing.
-- **Autopaginate iterators** — every paginated endpoint ships a `*_autopaginate` variant that transparently walks all pages. One `for` loop, all records.
-- **Automatic token management** — OAuth token is acquired, cached, and proactively refreshed 5 minutes before expiry. Thread-safe with double-checked locking.
+- **Autopaginate iterators** — every paginated endpoint ships a `*_autopaginate` variant that transparently walks all pages. One `for` loop (or `async for`), all records.
+- **Automatic token management** — OAuth token is acquired, cached, and proactively refreshed 5 minutes before expiry. Thread-safe (sync) and coroutine-safe (async) with double-checked locking.
 - **Retry with exponential backoff** — transient errors (5xx, 429) are retried automatically with jitter and `RateLimit-Reset` awareness. Configurable via `max_retries`.
 - **Proactive rate limit tracking** — monitors remaining requests per window and backs off before hitting the limit.
 - **Clean exception hierarchy** — catch only what you care about: `AuthenticationError`, `RateLimitError`, `NotFoundError`, `BadRequestError`, and more.
-- **httpx under the hood** — persistent connection pool, configurable timeouts, context manager support.
+- **httpx under the hood** — persistent connection pool, configurable timeouts, context manager support (`with` and `async with`).
 - **Forward-compatible kwargs** — extra `**kwargs` are passed directly as query params, so you can use undocumented or newly added Hotmart parameters without waiting for an SDK update.
 
 ---
 
 ## Design Principles
 
-- **One object, all resources.** Instantiate `Hotmart` once and access every resource group as an attribute: `client.sales`, `client.subscriptions`, `client.products`, etc.
+- **One object, all resources.** Instantiate `Hotmart` (or `AsyncHotmart`) once and access every resource group as an attribute: `client.sales`, `client.subscriptions`, `client.products`, etc.
 - **Fail loudly.** Errors are typed exceptions, never silently swallowed or buried in return values.
 - **No boilerplate.** Authentication, pagination, retries, and connection management are invisible by default. Opt in to configuration only when you need it.
 - **Strict typing.** `mypy --strict` passes. All public APIs are fully annotated. Models use `extra="allow"` so new API fields don't break your code.
@@ -56,6 +57,7 @@ This SDK handles OAuth, token refresh, retries, rate limits, and pagination auto
 - [Sandbox Mode](#sandbox-mode)
 - [Error Handling](#error-handling)
 - [Logging](#logging)
+- [Async Client](#async-client)
 - [Context Manager](#context-manager)
 - [Extra Parameters (kwargs)](#extra-parameters-kwargs)
 - [Documentation](#documentation)
@@ -487,21 +489,75 @@ Tokens and credentials are masked in all log output.
 
 ---
 
+## Async Client
+
+`AsyncHotmart` provides the same API surface as `Hotmart`, but with native `async/await` support — ideal for `asyncio`-based frameworks like FastAPI, aiohttp, and Starlette.
+
+```python
+from hotmart import AsyncHotmart
+
+async with AsyncHotmart(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    basic="Basic your_base64_credentials",
+) as client:
+    # Single page
+    page = await client.sales.history(buyer_name="Paula")
+
+    # Autopaginate with async for
+    async for sale in client.sales.history_autopaginate(transaction_status="APPROVED"):
+        print(sale.purchase.transaction)
+
+    # Concurrent requests with asyncio.gather
+    import asyncio
+    sales, subs, products = await asyncio.gather(
+        client.sales.history(),
+        client.subscriptions.list(),
+        client.products.list(),
+    )
+```
+
+All resource methods, autopagination iterators, token refresh, retry logic, and rate limiting work identically to the sync client. The constructor accepts the same parameters:
+
+```python
+client = AsyncHotmart(
+    client_id="...",
+    client_secret="...",
+    basic="Basic ...",
+    sandbox=False,       # same as sync
+    max_retries=3,       # same as sync
+    timeout=30.0,        # same as sync
+    log_level=logging.WARNING,
+)
+```
+
+> **Resource cleanup:** Always use `async with` or call `await client.aclose()` explicitly. Without cleanup, the underlying `httpx.AsyncClient` will leak connections.
+
+---
+
 ## Context Manager
 
-`Hotmart` supports the context manager protocol for automatic cleanup of the underlying HTTP connection pool:
+Both `Hotmart` and `AsyncHotmart` support context managers for automatic cleanup of the underlying HTTP connection pool:
 
 ```python
 from hotmart import Hotmart
 
-with Hotmart(
-    client_id="...",
-    client_secret="...",
-    basic="Basic ...",
-) as client:
+# Sync
+with Hotmart(client_id="...", client_secret="...", basic="Basic ...") as client:
     for sale in client.sales.history_autopaginate():
         print(sale.purchase.transaction)
 ```
+
+```python
+from hotmart import AsyncHotmart
+
+# Async
+async with AsyncHotmart(client_id="...", client_secret="...", basic="Basic ...") as client:
+    async for sale in client.sales.history_autopaginate():
+        print(sale.purchase.transaction)
+```
+
+For long-lived clients outside a context manager, call `client.close()` (sync) or `await client.aclose()` (async) explicitly.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@ O formato segue [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) e o pro
 
 ---
 
+## [1.1.0] - 2026-04-23
+
+### Added
+
+- **`AsyncHotmart` client** — native async support via `httpx.AsyncClient`, `asyncio.Lock`, and `async/await` throughout. Full feature parity with the sync `Hotmart` client. Closes [#17](https://github.com/im-voracity/hotmart-python/issues/17)
+- All 7 async resource groups: `AsyncSales`, `AsyncSubscriptions`, `AsyncProducts`, `AsyncCoupons`, `AsyncClub`, `AsyncEvents`, `AsyncNegotiation`
+- `AsyncIterator`-based autopagination (`async for item in client.sales.history_autopaginate():`)
+- `async with AsyncHotmart(...) as client:` context manager with `aclose()` for explicit cleanup
+- `close()` method on sync `Hotmart` client (mirrors `aclose()` on async)
+- 44 async unit tests + 24 async integration tests against the real Hotmart API
+- `pytest-asyncio` added to dev dependencies with `asyncio_mode = "auto"`
+
+### Design decision
+
+Independent parallel implementation (duplication) was chosen over shared generics, async-first wrappers, or transport abstractions. At ~1,050 lines of source, duplication is the most pragmatic approach — no breaking changes, no runtime overhead, no complex typing. Sync-safe modules (`_config`, `_exceptions`, `_logging`, `_retry`, `models/`) are reused without duplication.
+
+---
+
 ## [1.0.4] - 2026-03-28
 
 Versão de manutenção com melhorias de documentação. Nenhuma mudança no código da biblioteca.

--- a/docs/README-ptBR.md
+++ b/docs/README-ptBR.md
@@ -15,20 +15,21 @@ Este SDK cuida de autenticação OAuth, refresh de token, retentativas, rate lim
 
 ## Recursos
 
+- **Clientes sync e async** — `Hotmart` para código síncrono, `AsyncHotmart` para frameworks `asyncio`/`async`-first (FastAPI, aiohttp, etc.). Mesma API, paridade total de funcionalidades.
 - **Respostas totalmente tipadas** — cada resposta da API é um modelo Pydantic v2. Seu IDE completa os campos; sem dicts crus, sem adivinhações.
-- **Iteradores de autopaginação** — todo endpoint paginado tem uma variante `*_autopaginate` que percorre todas as páginas automaticamente. Um `for`, todos os registros.
-- **Gerenciamento automático de token** — o token OAuth é obtido, armazenado em cache e renovado proativamente 5 minutos antes do vencimento. Thread-safe com double-checked locking.
+- **Iteradores de autopaginação** — todo endpoint paginado tem uma variante `*_autopaginate` que percorre todas as páginas automaticamente. Um `for` (ou `async for`), todos os registros.
+- **Gerenciamento automático de token** — o token OAuth é obtido, armazenado em cache e renovado proativamente 5 minutos antes do vencimento. Thread-safe (sync) e coroutine-safe (async) com double-checked locking.
 - **Retry com backoff exponencial** — erros transitórios (5xx, 429) são reprocessados automaticamente com jitter e respeito ao `RateLimit-Reset`. Configurável via `max_retries`.
 - **Controle proativo de rate limit** — monitora as requisições restantes por janela e recua antes de atingir o limite.
 - **Hierarquia de exceções clara** — capture apenas o que interessa: `AuthenticationError`, `RateLimitError`, `NotFoundError`, `BadRequestError`, entre outros.
-- **httpx por baixo** — pool de conexões persistente, timeouts configuráveis, suporte a gerenciador de contexto.
+- **httpx por baixo** — pool de conexões persistente, timeouts configuráveis, suporte a gerenciador de contexto (`with` e `async with`).
 - **kwargs forward-compatible** — `**kwargs` extras são repassados diretamente como query params, permitindo usar parâmetros novos ou não documentados da Hotmart sem aguardar atualizações do SDK.
 
 ---
 
 ## Princípios de Design
 
-- **Um objeto, todos os recursos.** Instancie `Hotmart` uma vez e acesse cada grupo de recursos como atributo: `client.sales`, `client.subscriptions`, `client.products`, etc.
+- **Um objeto, todos os recursos.** Instancie `Hotmart` (ou `AsyncHotmart`) uma vez e acesse cada grupo de recursos como atributo: `client.sales`, `client.subscriptions`, `client.products`, etc.
 - **Falhe alto.** Erros são exceções tipadas, nunca suprimidos silenciosamente ou escondidos em valores de retorno.
 - **Sem boilerplate.** Autenticação, paginação, retentativas e gerenciamento de conexão são invisíveis por padrão. Configuração é opt-in.
 - **Tipagem estrita.** `mypy --strict` passa. Todas as APIs públicas são totalmente anotadas. Modelos usam `extra="allow"` para que novos campos da API não quebrem seu código.
@@ -52,6 +53,7 @@ Este SDK cuida de autenticação OAuth, refresh de token, retentativas, rate lim
 - [Modo Sandbox](#modo-sandbox)
 - [Tratamento de Erros](#tratamento-de-erros)
 - [Logging](#logging)
+- [Cliente Async](#cliente-async)
 - [Gerenciador de Contexto](#gerenciador-de-contexto)
 - [Parâmetros Extras (kwargs)](#parâmetros-extras-kwargs)
 - [Contribuindo](#contribuindo)
@@ -486,21 +488,75 @@ Tokens e credenciais são mascarados em toda saída de log.
 
 ---
 
+## Cliente Async
+
+`AsyncHotmart` oferece a mesma API que `Hotmart`, mas com suporte nativo a `async/await` — ideal para frameworks baseados em `asyncio` como FastAPI, aiohttp e Starlette.
+
+```python
+from hotmart import AsyncHotmart
+
+async with AsyncHotmart(
+    client_id="seu_client_id",
+    client_secret="seu_client_secret",
+    basic="Basic suas_credenciais_base64",
+) as client:
+    # Página única
+    pagina = await client.sales.history(buyer_name="Paula")
+
+    # Autopaginação com async for
+    async for venda in client.sales.history_autopaginate(transaction_status="APPROVED"):
+        print(venda.purchase.transaction)
+
+    # Requisições concorrentes com asyncio.gather
+    import asyncio
+    vendas, assinaturas, produtos = await asyncio.gather(
+        client.sales.history(),
+        client.subscriptions.list(),
+        client.products.list(),
+    )
+```
+
+Todos os métodos de recursos, iteradores de autopaginação, refresh de token, retry e rate limiting funcionam de forma idêntica ao cliente sync. O construtor aceita os mesmos parâmetros:
+
+```python
+client = AsyncHotmart(
+    client_id="...",
+    client_secret="...",
+    basic="Basic ...",
+    sandbox=False,       # igual ao sync
+    max_retries=3,       # igual ao sync
+    timeout=30.0,        # igual ao sync
+    log_level=logging.WARNING,
+)
+```
+
+> **Limpeza de recursos:** Sempre use `async with` ou chame `await client.aclose()` explicitamente. Sem limpeza, o `httpx.AsyncClient` interno vai vazar conexões.
+
+---
+
 ## Gerenciador de Contexto
 
-`Hotmart` suporta o protocolo de gerenciador de contexto para limpeza automática do pool de conexões HTTP:
+Tanto `Hotmart` quanto `AsyncHotmart` suportam gerenciadores de contexto para limpeza automática do pool de conexões HTTP:
 
 ```python
 from hotmart import Hotmart
 
-with Hotmart(
-    client_id="...",
-    client_secret="...",
-    basic="Basic ...",
-) as client:
+# Sync
+with Hotmart(client_id="...", client_secret="...", basic="Basic ...") as client:
     for venda in client.sales.history_autopaginate():
         print(venda.purchase.transaction)
 ```
+
+```python
+from hotmart import AsyncHotmart
+
+# Async
+async with AsyncHotmart(client_id="...", client_secret="...", basic="Basic ...") as client:
+    async for venda in client.sales.history_autopaginate():
+        print(venda.purchase.transaction)
+```
+
+Para clientes de longa duração fora de um context manager, chame `client.close()` (sync) ou `await client.aclose()` (async) explicitamente.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hotmart-python"
-version = "1.0.4"
+version = "1.1.0"
 description = "Python SDK for the Hotmart API"
 authors = [{ name = "Matheus Tenório", email = "matheusct16@gmail.com" }]
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "pytest-asyncio>=0.23",
     "respx>=0.21",
     "ruff>=0.4",
     "mypy>=1.10",
@@ -40,6 +41,7 @@ strict = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 markers = [
     "integration: testes contra a API real da Hotmart (requer credenciais)",
 ]

--- a/src/hotmart/__init__.py
+++ b/src/hotmart/__init__.py
@@ -1,3 +1,4 @@
+from ._async_client import AsyncHotmart
 from ._client import Hotmart
 from ._exceptions import (
     APIStatusError,
@@ -41,10 +42,11 @@ from .models import (
     TicketItem,
 )
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "Hotmart",
+    "AsyncHotmart",
     "PaginatedResponse", "Price", "PageInfo",
     "PurchaseStatus", "SubscriptionStatus", "PaymentType",
     "CommissionSource", "ProductStatus", "ProductFormat",

--- a/src/hotmart/_async_auth.py
+++ b/src/hotmart/_async_auth.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+
+from ._config import AUTH_URL, ClientConfig
+
+_REFRESH_BUFFER = 300  # refresh 5 min before expiry
+
+
+class AsyncTokenManager:
+    def __init__(self, config: ClientConfig) -> None:
+        self._config = config
+        self._token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    async def get_token(self) -> str:
+        if self._is_valid():
+            return self._token  # type: ignore[return-value]
+
+        async with self._lock:
+            if self._is_valid():
+                return self._token  # type: ignore[return-value]
+            return await self._refresh()
+
+    async def invalidate(self) -> None:
+        async with self._lock:
+            self._token = None
+            self._expires_at = 0.0
+
+    def _is_valid(self) -> bool:
+        return self._token is not None and time.time() < self._expires_at - _REFRESH_BUFFER
+
+    async def _refresh(self) -> str:
+        async with httpx.AsyncClient() as c:
+            response = await c.post(
+                AUTH_URL,
+                headers={"Authorization": self._config.basic},
+                params={
+                    "grant_type": "client_credentials",
+                    "client_id": self._config.client_id,
+                    "client_secret": self._config.client_secret,
+                },
+            )
+        response.raise_for_status()
+        data = response.json()
+        self._token = data["access_token"]
+        self._expires_at = time.time() + data["expires_in"]
+        return self._token  # type: ignore[return-value]

--- a/src/hotmart/_async_auth.py
+++ b/src/hotmart/_async_auth.py
@@ -49,4 +49,5 @@ class AsyncTokenManager:
         data = response.json()
         self._token = data["access_token"]
         self._expires_at = time.time() + data["expires_in"]
-        return self._token  # type: ignore[return-value]
+        assert self._token is not None
+        return self._token

--- a/src/hotmart/_async_base_client.py
+++ b/src/hotmart/_async_base_client.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import Any, TypeVar
+
+import httpx
+
+from ._async_auth import AsyncTokenManager
+from ._async_rate_limit import AsyncRateLimitTracker
+from ._base_client import _build_params
+from ._config import BASE_URLS, ClientConfig
+from ._exceptions import make_status_error
+from ._logging import HotmartLogger
+from ._retry import get_retry_delay, is_retryable
+
+T = TypeVar("T")
+
+# Re-export for async resources to import from here or _base_client
+__all__ = ["BaseAsyncClient", "_build_params"]
+
+
+class BaseAsyncClient:
+    def __init__(self, config: ClientConfig) -> None:
+        self._config = config
+        self._token_manager = AsyncTokenManager(config)
+        self._rate_limiter = AsyncRateLimitTracker()
+        self._logger = HotmartLogger(config.log_level)
+        self._http = httpx.AsyncClient(timeout=config.timeout, verify=True)
+
+    async def __aenter__(self) -> BaseAsyncClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self._http.aclose()
+
+    def _base_url(self, api_domain: str) -> str:
+        env = "sandbox" if self._config.sandbox else "prod"
+        return BASE_URLS[env][api_domain]
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        api_domain: str = "payments",
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        cast_to: type[T] | None = None,
+    ) -> T | None:
+        url = f"{self._base_url(api_domain)}{path}"
+        request_id = str(uuid.uuid4())
+
+        await self._rate_limiter.wait_if_needed()
+        token = await self._token_manager.get_token()
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+        self._logger.request(method=method, url=url, request_id=request_id, params=params)
+
+        response = await self._execute_with_retry(method, url, headers, params, json, request_id)
+
+        if response.status_code == 401:
+            await self._token_manager.invalidate()
+            token = await self._token_manager.get_token()
+            headers["Authorization"] = f"Bearer {token}"
+            response = await self._http.request(method, url, headers=headers, params=params, json=json)
+            if not response.is_success:
+                raise make_status_error(response)
+
+        await self._rate_limiter.update(response.headers)
+
+        if not response.is_success:
+            raise make_status_error(response)
+
+        if cast_to is None:
+            content = response.content
+            if not content or content == b"{}":
+                return None
+            return response.json()  # type: ignore[return-value]
+
+        if not response.content or response.content == b"{}":
+            return cast_to.model_validate({})  # type: ignore[union-attr]
+
+        return cast_to.model_validate(response.json())  # type: ignore[union-attr]
+
+    async def _execute_with_retry(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        json: dict[str, Any] | None,
+        request_id: str,
+    ) -> httpx.Response:
+        response: httpx.Response | None = None
+
+        for attempt in range(self._config.max_retries + 1):
+            start = time.monotonic()
+            try:
+                response = await self._http.request(method, url, headers=headers, params=params, json=json)
+            except httpx.TransportError:
+                if attempt >= self._config.max_retries:
+                    raise
+                delay = get_retry_delay(attempt)
+                self._logger.retry(attempt=attempt + 1, max_retries=self._config.max_retries,
+                                   delay=delay, status_code=0, request_id=request_id)
+                await asyncio.sleep(delay)
+                continue
+
+            duration_ms = (time.monotonic() - start) * 1000
+            self._logger.response(request_id=request_id, status_code=response.status_code,
+                                  duration_ms=duration_ms)
+
+            if not is_retryable(response.status_code) or attempt >= self._config.max_retries:
+                return response
+
+            delay = get_retry_delay(attempt, response)
+            self._logger.retry(attempt=attempt + 1, max_retries=self._config.max_retries,
+                               delay=delay, status_code=response.status_code, request_id=request_id)
+            await asyncio.sleep(delay)
+
+        return response  # type: ignore[return-value]
+
+    async def _get(self, path: str, *, api_domain: str = "payments",
+                   params: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._request("GET", path, api_domain=api_domain, params=params, cast_to=cast_to)
+
+    async def _post(self, path: str, *, api_domain: str = "payments",
+                    json: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._request("POST", path, api_domain=api_domain, json=json, cast_to=cast_to)
+
+    async def _put(self, path: str, *, api_domain: str = "payments",
+                   json: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._request("PUT", path, api_domain=api_domain, json=json, cast_to=cast_to)
+
+    async def _patch(self, path: str, *, api_domain: str = "payments",
+                     json: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._request("PATCH", path, api_domain=api_domain, json=json, cast_to=cast_to)
+
+    async def _delete(self, path: str, *, api_domain: str = "payments",
+                      cast_to: type[T] | None = None) -> T | None:
+        return await self._request("DELETE", path, api_domain=api_domain, cast_to=cast_to)

--- a/src/hotmart/_async_base_client.py
+++ b/src/hotmart/_async_base_client.py
@@ -77,12 +77,12 @@ class BaseAsyncClient:
             content = response.content
             if not content or content == b"{}":
                 return None
-            return response.json()  # type: ignore[return-value]
+            return response.json()  # type: ignore[no-any-return]
 
         if not response.content or response.content == b"{}":
-            return cast_to.model_validate({})  # type: ignore[union-attr]
+            return cast_to.model_validate({})  # type: ignore[no-any-return, attr-defined]
 
-        return cast_to.model_validate(response.json())  # type: ignore[union-attr]
+        return cast_to.model_validate(response.json())  # type: ignore[no-any-return, attr-defined]
 
     async def _execute_with_retry(
         self,

--- a/src/hotmart/_async_base_client.py
+++ b/src/hotmart/_async_base_client.py
@@ -33,6 +33,9 @@ class BaseAsyncClient:
         return self
 
     async def __aexit__(self, *_: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
         await self._http.aclose()
 
     def _base_url(self, api_domain: str) -> str:

--- a/src/hotmart/_async_client.py
+++ b/src/hotmart/_async_client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+
+from ._async_base_client import BaseAsyncClient
+from ._config import ClientConfig
+from .resources.async_club import AsyncClub
+from .resources.async_coupons import AsyncCoupons
+from .resources.async_events import AsyncEvents
+from .resources.async_negotiation import AsyncNegotiation
+from .resources.async_products import AsyncProducts
+from .resources.async_sales import AsyncSales
+from .resources.async_subscriptions import AsyncSubscriptions
+
+
+class AsyncHotmart(BaseAsyncClient):
+    """
+    Async client for the Hotmart API.
+
+    Cliente assíncrono para a API da Hotmart.
+
+    Usage / Uso::
+
+        async with AsyncHotmart(client_id="...", client_secret="...", basic="Basic ...") as client:
+            sales = await client.sales.history(buyer_name="Paula")
+    """
+
+    sales: AsyncSales
+    subscriptions: AsyncSubscriptions
+    products: AsyncProducts
+    coupons: AsyncCoupons
+    club: AsyncClub
+    events: AsyncEvents
+    negotiation: AsyncNegotiation
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        basic: str,
+        sandbox: bool = False,
+        max_retries: int = 3,
+        timeout: float = 30.0,
+        log_level: int = logging.WARNING,
+    ) -> None:
+        config = ClientConfig(
+            client_id=client_id,
+            client_secret=client_secret,
+            basic=basic,
+            sandbox=sandbox,
+            max_retries=max_retries,
+            timeout=timeout,
+            log_level=log_level,
+        )
+        super().__init__(config)
+        self.sales = AsyncSales(self)
+        self.subscriptions = AsyncSubscriptions(self)
+        self.products = AsyncProducts(self)
+        self.coupons = AsyncCoupons(self)
+        self.club = AsyncClub(self)
+        self.events = AsyncEvents(self)
+        self.negotiation = AsyncNegotiation(self)

--- a/src/hotmart/_async_rate_limit.py
+++ b/src/hotmart/_async_rate_limit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+
+
+class AsyncRateLimitTracker:
+    def __init__(self) -> None:
+        self._remaining: int = 500
+        self._reset_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    async def update(self, headers: httpx.Headers) -> None:
+        remaining = headers.get("RateLimit-Remaining")
+        reset = headers.get("RateLimit-Reset")
+
+        async with self._lock:
+            if remaining is not None:
+                self._remaining = int(remaining)
+            if reset is not None:
+                self._reset_at = time.time() + float(reset)
+
+    async def wait_if_needed(self) -> None:
+        async with self._lock:
+            if self._remaining > 0:
+                return
+            sleep_for = max(0.0, self._reset_at - time.time())
+
+        if sleep_for > 0:
+            await asyncio.sleep(sleep_for)

--- a/src/hotmart/_base_client.py
+++ b/src/hotmart/_base_client.py
@@ -40,6 +40,9 @@ class BaseSyncClient:
         return self
 
     def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
         self._http.close()
 
     def _base_url(self, api_domain: str) -> str:

--- a/src/hotmart/resources/_async_base.py
+++ b/src/hotmart/resources/_async_base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from .._async_base_client import BaseAsyncClient
+
+T = TypeVar("T")
+
+
+class AsyncAPIResource:
+    def __init__(self, client: BaseAsyncClient) -> None:
+        self._client = client
+
+    async def _get(self, path: str, *, api_domain: str = "payments",
+                   params: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._client._get(path, api_domain=api_domain, params=params, cast_to=cast_to)
+
+    async def _post(self, path: str, *, api_domain: str = "payments",
+                    json: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._client._post(path, api_domain=api_domain, json=json, cast_to=cast_to)
+
+    async def _put(self, path: str, *, api_domain: str = "payments",
+                   json: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._client._put(path, api_domain=api_domain, json=json, cast_to=cast_to)
+
+    async def _patch(self, path: str, *, api_domain: str = "payments",
+                     json: dict[str, Any] | None = None, cast_to: type[T] | None = None) -> T | None:
+        return await self._client._patch(path, api_domain=api_domain, json=json, cast_to=cast_to)
+
+    async def _delete(self, path: str, *, api_domain: str = "payments",
+                      cast_to: type[T] | None = None) -> T | None:
+        return await self._client._delete(path, api_domain=api_domain, cast_to=cast_to)

--- a/src/hotmart/resources/async_club.py
+++ b/src/hotmart/resources/async_club.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..models.club import ModuleItem, PageItem, StudentItem, StudentProgress
+from ._async_base import AsyncAPIResource
+
+
+class AsyncClub(AsyncAPIResource):
+
+    async def modules(self, subdomain: str, *, is_extra: bool | None = None, **kwargs: Any) -> list[ModuleItem]:
+        """Return list of modules for the given subdomain.
+
+        Retorna lista de módulos para o subdomínio informado.
+        """
+        params: dict[str, Any] = {"subdomain": subdomain}
+        if is_extra is not None:
+            params["is_extra"] = is_extra
+        params.update(kwargs)
+        data = await self._get("/modules", api_domain="club", params=params)
+        if not data:
+            return []
+        return [ModuleItem.model_validate(item) for item in data]
+
+    async def pages(self, subdomain: str, module_id: str, **kwargs: Any) -> list[PageItem]:
+        """Return list of pages for the given module.
+
+        Retorna lista de páginas para o módulo informado.
+        """
+        params: dict[str, Any] = {"subdomain": subdomain, "module_id": module_id, **kwargs}
+        data = await self._get("/pages", api_domain="club", params=params)
+        if not data:
+            return []
+        return [PageItem.model_validate(item) for item in data]
+
+    async def students(self, subdomain: str, **kwargs: Any) -> list[StudentItem]:
+        """Return list of students for the given subdomain.
+
+        Retorna lista de alunos para o subdomínio informado.
+        """
+        params: dict[str, Any] = {"subdomain": subdomain, **kwargs}
+        data = await self._get("/students", api_domain="club", params=params)
+        if not data:
+            return []
+        return [StudentItem.model_validate(item) for item in data]
+
+    async def student_progress(
+        self, subdomain: str, *, student_email: str | None = None, **kwargs: Any
+    ) -> list[StudentProgress]:
+        """Return progress data for students in the given subdomain.
+
+        Retorna dados de progresso dos alunos no subdomínio informado.
+        """
+        params: dict[str, Any] = {"subdomain": subdomain}
+        if student_email is not None:
+            params["student_email"] = student_email
+        params.update(kwargs)
+        data = await self._get("/students/progress", api_domain="club", params=params)
+        if not data:
+            return []
+        return [StudentProgress.model_validate(item) for item in data]

--- a/src/hotmart/resources/async_club.py
+++ b/src/hotmart/resources/async_club.py
@@ -17,7 +17,7 @@ class AsyncClub(AsyncAPIResource):
         if is_extra is not None:
             params["is_extra"] = is_extra
         params.update(kwargs)
-        data = await self._get("/modules", api_domain="club", params=params)
+        data: Any = await self._get("/modules", api_domain="club", params=params)
         if not data:
             return []
         return [ModuleItem.model_validate(item) for item in data]
@@ -28,7 +28,7 @@ class AsyncClub(AsyncAPIResource):
         Retorna lista de páginas para o módulo informado.
         """
         params: dict[str, Any] = {"subdomain": subdomain, "module_id": module_id, **kwargs}
-        data = await self._get("/pages", api_domain="club", params=params)
+        data: Any = await self._get("/pages", api_domain="club", params=params)
         if not data:
             return []
         return [PageItem.model_validate(item) for item in data]
@@ -39,7 +39,7 @@ class AsyncClub(AsyncAPIResource):
         Retorna lista de alunos para o subdomínio informado.
         """
         params: dict[str, Any] = {"subdomain": subdomain, **kwargs}
-        data = await self._get("/students", api_domain="club", params=params)
+        data: Any = await self._get("/students", api_domain="club", params=params)
         if not data:
             return []
         return [StudentItem.model_validate(item) for item in data]
@@ -55,7 +55,7 @@ class AsyncClub(AsyncAPIResource):
         if student_email is not None:
             params["student_email"] = student_email
         params.update(kwargs)
-        data = await self._get("/students/progress", api_domain="club", params=params)
+        data: Any = await self._get("/students/progress", api_domain="club", params=params)
         if not data:
             return []
         return [StudentProgress.model_validate(item) for item in data]

--- a/src/hotmart/resources/async_coupons.py
+++ b/src/hotmart/resources/async_coupons.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from ..models.coupons import CouponItem
+from ..models.pagination import PaginatedResponse
+from ._async_base import AsyncAPIResource
+
+
+class AsyncCoupons(AsyncAPIResource):
+
+    async def create(self, product_id: str, coupon_code: str, discount: float) -> None:
+        await self._post(f"/product/{product_id}/coupon", json={"code": coupon_code, "discount": discount})
+
+    async def list(
+        self,
+        product_id: str,
+        *,
+        code: str | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[CouponItem]:
+        params: dict[str, Any] = {}
+        if code is not None:
+            params["code"] = code
+        if page_token is not None:
+            params["page_token"] = page_token
+        params.update(kwargs)
+        return await self._get(f"/coupon/product/{product_id}", params=params, cast_to=PaginatedResponse[CouponItem])  # type: ignore[return-value]
+
+    async def list_autopaginate(self, product_id: str, **kwargs: Any) -> AsyncIterator[CouponItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.list(product_id, page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def delete(self, coupon_id: str) -> None:
+        await self._delete(f"/coupon/{coupon_id}")

--- a/src/hotmart/resources/async_events.py
+++ b/src/hotmart/resources/async_events.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from .._base_client import _build_params
+from ..models.events import EventItem, TicketItem
+from ..models.pagination import PaginatedResponse
+from ._async_base import AsyncAPIResource
+
+
+class AsyncEvents(AsyncAPIResource):
+
+    async def get(self, event_id: str, **kwargs: Any) -> EventItem | None:
+        return await self._get(f"/events/{event_id}", cast_to=EventItem)
+
+    async def tickets(
+        self,
+        *,
+        product_id: int,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[TicketItem]:
+        params = _build_params(locals())
+        return await self._get("/tickets", params=params, cast_to=PaginatedResponse[TicketItem])  # type: ignore[return-value]
+
+    async def tickets_autopaginate(self, *, product_id: int, **kwargs: Any) -> AsyncIterator[TicketItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.tickets(product_id=product_id, page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token

--- a/src/hotmart/resources/async_negotiation.py
+++ b/src/hotmart/resources/async_negotiation.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from ..models.negotiation import NegotiationResponse
+from ._async_base import AsyncAPIResource
+
+
+class AsyncNegotiation(AsyncAPIResource):
+
+    async def create(self, subscriber_code: str) -> NegotiationResponse | None:
+        return await self._post("/negotiation", json={"subscriber_code": subscriber_code}, cast_to=NegotiationResponse)

--- a/src/hotmart/resources/async_products.py
+++ b/src/hotmart/resources/async_products.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from .._base_client import _build_params
+from ..models._enums import ProductFormat, ProductStatus
+from ..models.pagination import PaginatedResponse
+from ..models.products import OfferItem, PlanItem, ProductItem
+from ._async_base import AsyncAPIResource
+
+
+class AsyncProducts(AsyncAPIResource):
+
+    async def list(
+        self,
+        *,
+        id: int | None = None,
+        status: ProductStatus | str | None = None,
+        format: ProductFormat | str | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[ProductItem]:
+        params = _build_params(locals())
+        return await self._get(  # type: ignore[return-value]
+            "/products", api_domain="products", params=params, cast_to=PaginatedResponse[ProductItem]
+        )
+
+    async def list_autopaginate(self, **kwargs: Any) -> AsyncIterator[ProductItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.list(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def offers(
+        self,
+        ucode: str,
+        *,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[OfferItem]:
+        params = _build_params(locals())
+        params.pop("ucode", None)
+        return await self._get(  # type: ignore[return-value]
+            f"/products/{ucode}/offers", api_domain="products", params=params, cast_to=PaginatedResponse[OfferItem]
+        )
+
+    async def offers_autopaginate(self, ucode: str, **kwargs: Any) -> AsyncIterator[OfferItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.offers(ucode, page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def plans(
+        self,
+        ucode: str,
+        *,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[PlanItem]:
+        params = _build_params(locals())
+        params.pop("ucode", None)
+        return await self._get(  # type: ignore[return-value]
+            f"/products/{ucode}/plans", api_domain="products", params=params, cast_to=PaginatedResponse[PlanItem]
+        )
+
+    async def plans_autopaginate(self, ucode: str, **kwargs: Any) -> AsyncIterator[PlanItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.plans(ucode, page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token

--- a/src/hotmart/resources/async_sales.py
+++ b/src/hotmart/resources/async_sales.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from .._base_client import _build_params
+from ..models._enums import CommissionSource, PaymentType, PurchaseStatus
+from ..models.pagination import PaginatedResponse
+from ..models.sales import (
+    SaleCommissionsItem,
+    SaleHistoryItem,
+    SaleParticipantsItem,
+    SalePriceDetailsItem,
+    SaleSummaryItem,
+)
+from ._async_base import AsyncAPIResource
+
+
+class AsyncSales(AsyncAPIResource):
+
+    async def history(
+        self,
+        *,
+        product_id: int | None = None,
+        start_date: int | None = None,
+        end_date: int | None = None,
+        sales_source: str | None = None,
+        transaction: str | None = None,
+        buyer_name: str | None = None,
+        buyer_email: str | None = None,
+        transaction_status: PurchaseStatus | str | None = None,
+        payment_type: PaymentType | str | None = None,
+        offer_code: str | None = None,
+        commission_as: CommissionSource | str | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SaleHistoryItem]:
+        params = _build_params(locals())
+        return await self._get("/sales/history", params=params, cast_to=PaginatedResponse[SaleHistoryItem])  # type: ignore[return-value]
+
+    async def history_autopaginate(self, **kwargs: Any) -> AsyncIterator[SaleHistoryItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.history(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def summary(
+        self,
+        *,
+        product_id: int | None = None,
+        start_date: int | None = None,
+        end_date: int | None = None,
+        sales_source: str | None = None,
+        affiliate_name: str | None = None,
+        payment_type: PaymentType | str | None = None,
+        offer_code: str | None = None,
+        transaction: str | None = None,
+        transaction_status: PurchaseStatus | str | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SaleSummaryItem]:
+        params = _build_params(locals())
+        return await self._get("/sales/summary", params=params, cast_to=PaginatedResponse[SaleSummaryItem])  # type: ignore[return-value]
+
+    async def summary_autopaginate(self, **kwargs: Any) -> AsyncIterator[SaleSummaryItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.summary(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def participants(
+        self,
+        *,
+        product_id: int | None = None,
+        start_date: int | None = None,
+        end_date: int | None = None,
+        buyer_email: str | None = None,
+        buyer_name: str | None = None,
+        sales_source: str | None = None,
+        transaction: str | None = None,
+        affiliate_name: str | None = None,
+        commission_as: CommissionSource | str | None = None,
+        transaction_status: PurchaseStatus | str | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SaleParticipantsItem]:
+        params = _build_params(locals())
+        return await self._get("/sales/users", params=params, cast_to=PaginatedResponse[SaleParticipantsItem])  # type: ignore[return-value]
+
+    async def participants_autopaginate(self, **kwargs: Any) -> AsyncIterator[SaleParticipantsItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.participants(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def commissions(
+        self,
+        *,
+        product_id: int | None = None,
+        start_date: int | None = None,
+        end_date: int | None = None,
+        transaction: str | None = None,
+        commission_as: CommissionSource | str | None = None,
+        transaction_status: PurchaseStatus | str | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SaleCommissionsItem]:
+        params = _build_params(locals())
+        return await self._get("/sales/commissions", params=params, cast_to=PaginatedResponse[SaleCommissionsItem])  # type: ignore[return-value]
+
+    async def commissions_autopaginate(self, **kwargs: Any) -> AsyncIterator[SaleCommissionsItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.commissions(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def price_details(
+        self,
+        *,
+        product_id: int | None = None,
+        start_date: int | None = None,
+        end_date: int | None = None,
+        transaction: str | None = None,
+        transaction_status: PurchaseStatus | str | None = None,
+        payment_type: PaymentType | str | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SalePriceDetailsItem]:
+        params = _build_params(locals())
+        return await self._get("/sales/price/details", params=params, cast_to=PaginatedResponse[SalePriceDetailsItem])  # type: ignore[return-value]
+
+    async def price_details_autopaginate(self, **kwargs: Any) -> AsyncIterator[SalePriceDetailsItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.price_details(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def refund(self, transaction_code: str) -> None:
+        await self._put(f"/sales/{transaction_code}/refund")

--- a/src/hotmart/resources/async_subscriptions.py
+++ b/src/hotmart/resources/async_subscriptions.py
@@ -80,13 +80,13 @@ class AsyncSubscriptions(AsyncAPIResource):
             page_token = page.page_info.next_page_token
 
     async def purchases(self, subscriber_code: str, **kwargs: Any) -> list[SubscriptionPurchase]:
-        data = await self._get(f"/subscriptions/{subscriber_code}/purchases")
+        data: Any = await self._get(f"/subscriptions/{subscriber_code}/purchases")
         if not data:
             return []
         return [SubscriptionPurchase.model_validate(item) for item in data]
 
     async def transactions(self, subscriber_code: str, **kwargs: Any) -> list[Any]:
-        data = await self._get(f"/subscriptions/{subscriber_code}/transactions")
+        data: Any = await self._get(f"/subscriptions/{subscriber_code}/transactions")
         return data if data else []
 
     async def cancel(self, subscriber_code: list[str], *, send_mail: bool = True) -> SubscriptionBulkResponse | None:

--- a/src/hotmart/resources/async_subscriptions.py
+++ b/src/hotmart/resources/async_subscriptions.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from .._base_client import _build_params
+from ..models._enums import SubscriptionStatus
+from ..models.pagination import PaginatedResponse
+from ..models.subscriptions import (
+    SubscriptionBulkResponse,
+    SubscriptionItem,
+    SubscriptionPurchase,
+    SubscriptionResult,
+    SubscriptionSummaryItem,
+)
+from ._async_base import AsyncAPIResource
+
+
+class AsyncSubscriptions(AsyncAPIResource):
+
+    async def list(
+        self,
+        *,
+        product_id: int | None = None,
+        plan: list[str] | None = None,
+        plan_id: int | None = None,
+        accession_date: int | None = None,
+        end_accession_date: int | None = None,
+        status: SubscriptionStatus | str | None = None,
+        subscriber_code: str | None = None,
+        subscriber_email: str | None = None,
+        transaction: str | None = None,
+        trial: bool | None = None,
+        cancelation_date: int | None = None,
+        end_cancelation_date: int | None = None,
+        date_next_charge: int | None = None,
+        end_date_next_charge: int | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SubscriptionItem]:
+        params = _build_params(locals())
+        return await self._get("/subscriptions", params=params, cast_to=PaginatedResponse[SubscriptionItem])  # type: ignore[return-value]
+
+    async def list_autopaginate(self, **kwargs: Any) -> AsyncIterator[SubscriptionItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.list(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def summary(
+        self,
+        *,
+        product_id: int | None = None,
+        subscriber_code: str | None = None,
+        accession_date: int | None = None,
+        end_accession_date: int | None = None,
+        date_next_charge: int | None = None,
+        max_results: int | None = None,
+        page_token: str | None = None,
+        **kwargs: Any,
+    ) -> PaginatedResponse[SubscriptionSummaryItem]:
+        params = _build_params(locals())
+        return await self._get(  # type: ignore[return-value]
+            "/subscriptions/summary", params=params, cast_to=PaginatedResponse[SubscriptionSummaryItem]
+        )
+
+    async def summary_autopaginate(self, **kwargs: Any) -> AsyncIterator[SubscriptionSummaryItem]:
+        page_token: str | None = None
+        while True:
+            page = await self.summary(page_token=page_token, **kwargs)
+            for item in page.items:
+                yield item
+            if not page.page_info or not page.page_info.next_page_token:
+                break
+            page_token = page.page_info.next_page_token
+
+    async def purchases(self, subscriber_code: str, **kwargs: Any) -> list[SubscriptionPurchase]:
+        data = await self._get(f"/subscriptions/{subscriber_code}/purchases")
+        if not data:
+            return []
+        return [SubscriptionPurchase.model_validate(item) for item in data]
+
+    async def transactions(self, subscriber_code: str, **kwargs: Any) -> list[Any]:
+        data = await self._get(f"/subscriptions/{subscriber_code}/transactions")
+        return data if data else []
+
+    async def cancel(self, subscriber_code: list[str], *, send_mail: bool = True) -> SubscriptionBulkResponse | None:
+        body = {"subscriber_code": subscriber_code, "send_mail": send_mail}
+        return await self._post("/subscriptions/cancel", json=body, cast_to=SubscriptionBulkResponse)
+
+    async def reactivate(self, subscriber_code: list[str], *, charge: bool = False) -> SubscriptionBulkResponse | None:
+        body = {"subscriber_code": subscriber_code, "charge": charge}
+        return await self._post("/subscriptions/reactivate", json=body, cast_to=SubscriptionBulkResponse)
+
+    async def reactivate_single(self, subscriber_code: str, *, charge: bool = False) -> SubscriptionResult | None:
+        return await self._post(
+            f"/subscriptions/{subscriber_code}/reactivate",
+            json={"charge": charge},
+            cast_to=SubscriptionResult,
+        )
+
+    async def change_due_day(self, subscriber_code: str, due_day: int) -> None:
+        await self._patch(f"/subscriptions/{subscriber_code}", json={"due_day": due_day})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from hotmart import Hotmart
+from hotmart import AsyncHotmart, Hotmart
 
 TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
 
@@ -11,3 +11,13 @@ def client(respx_mock):
         "access_token": "test_token", "token_type": "bearer", "expires_in": 86400,
     }))
     return Hotmart(client_id="test_id", client_secret="test_secret", basic="Basic dGVzdA==", max_retries=0)
+
+
+@pytest.fixture
+async def async_client(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "test_token", "token_type": "bearer", "expires_in": 86400,
+    }))
+    async with AsyncHotmart(client_id="test_id", client_secret="test_secret",
+                            basic="Basic dGVzdA==", max_retries=0) as client:
+        yield client

--- a/tests/resources/test_async_club.py
+++ b/tests/resources/test_async_club.py
@@ -1,0 +1,44 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.resources.async_club import AsyncClub
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+CLUB_BASE = "https://developers.hotmart.com/club/api/v1"
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def club():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncClub(BaseAsyncClient(config))
+
+
+async def test_modules_returns_list(club, respx_mock):
+    data = [{"module_id": "m1", "name": "Module 1", "sequence": 1}]
+    respx_mock.get(f"{CLUB_BASE}/modules").mock(return_value=httpx.Response(200, json=data))
+    result = await club.modules("mysubdomain")
+    assert isinstance(result, list)
+    assert result[0].module_id == "m1"
+
+
+async def test_modules_passes_subdomain(club, respx_mock):
+    captured: list[httpx.Request] = []
+    def capture(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json=[])
+    respx_mock.get(f"{CLUB_BASE}/modules").mock(side_effect=capture)
+    await club.modules("mysubdomain")
+    assert "subdomain=mysubdomain" in str(captured[0].url)
+
+
+async def test_students_returns_list(club, respx_mock):
+    respx_mock.get(f"{CLUB_BASE}/students").mock(return_value=httpx.Response(200, json=[{"email": "s@test.com"}]))
+    result = await club.students("mysubdomain")
+    assert len(result) == 1

--- a/tests/resources/test_async_coupons.py
+++ b/tests/resources/test_async_coupons.py
@@ -1,0 +1,37 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.resources.async_coupons import AsyncCoupons
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+BASE = "https://developers.hotmart.com/payments/api/v1"
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def coupons():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncCoupons(BaseAsyncClient(config))
+
+
+async def test_create_posts_to_correct_url(coupons, respx_mock):
+    respx_mock.post(f"{BASE}/product/P123/coupon").mock(return_value=httpx.Response(200, text="{}"))
+    await coupons.create("P123", "SAVE20", 0.20)  # no error = success
+
+
+async def test_list_returns_paginated(coupons, respx_mock):
+    data = {"items": [{"code": "SAVE20", "discount": 0.20}], "page_info": {}}
+    respx_mock.get(f"{BASE}/coupon/product/P123").mock(return_value=httpx.Response(200, json=data))
+    result = await coupons.list("P123")
+    assert result.items[0].code == "SAVE20"
+
+
+async def test_delete_calls_delete_method(coupons, respx_mock):
+    respx_mock.delete(f"{BASE}/coupon/CPN1").mock(return_value=httpx.Response(200, text="{}"))
+    await coupons.delete("CPN1")  # no error = success

--- a/tests/resources/test_async_events.py
+++ b/tests/resources/test_async_events.py
@@ -1,0 +1,33 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.resources.async_events import AsyncEvents
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+BASE = "https://developers.hotmart.com/payments/api/v1"
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def events():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncEvents(BaseAsyncClient(config))
+
+
+async def test_get_event_calls_correct_path(events, respx_mock):
+    respx_mock.get(f"{BASE}/events/EVT1").mock(return_value=httpx.Response(200, json={"id": "EVT1"}))
+    result = await events.get("EVT1")
+    assert result is not None
+
+
+async def test_tickets_returns_paginated(events, respx_mock):
+    data = {"items": [{"ticket_id": "T1"}], "page_info": {}}
+    respx_mock.get(f"{BASE}/tickets").mock(return_value=httpx.Response(200, json=data))
+    result = await events.tickets(product_id=123)
+    assert len(result.items) == 1

--- a/tests/resources/test_async_negotiation.py
+++ b/tests/resources/test_async_negotiation.py
@@ -1,0 +1,33 @@
+import json
+
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.resources.async_negotiation import AsyncNegotiation
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+BASE = "https://developers.hotmart.com/payments/api/v1"
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def negotiation():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncNegotiation(BaseAsyncClient(config))
+
+
+async def test_create_posts_subscriber_code(negotiation, respx_mock):
+    captured: list[httpx.Request] = []
+    def capture(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json={"offer_url": "https://hotmart.com/offer"})
+    respx_mock.post(f"{BASE}/negotiation").mock(side_effect=capture)
+    await negotiation.create("ABC1")
+    body = json.loads(captured[0].content)
+    assert body["subscriber_code"] == "ABC1"

--- a/tests/resources/test_async_products.py
+++ b/tests/resources/test_async_products.py
@@ -1,0 +1,47 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.resources.async_products import AsyncProducts
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+PROD_BASE = "https://developers.hotmart.com/products/api/v1"
+
+PRODUCT_RESPONSE = {
+    "items": [{"id": 123, "name": "Course A", "ucode": "abc-123", "status": "ACTIVE", "format": "ONLINE_COURSE"}],
+    "page_info": {"results_per_page": 10},
+}
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def products():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncProducts(BaseAsyncClient(config))
+
+
+async def test_list_returns_products(products, respx_mock):
+    respx_mock.get(f"{PROD_BASE}/products").mock(return_value=httpx.Response(200, json=PRODUCT_RESPONSE))
+    result = await products.list()
+    assert result.items[0].name == "Course A"
+
+
+async def test_offers_uses_ucode_path(products, respx_mock):
+    respx_mock.get(f"{PROD_BASE}/products/abc-123/offers").mock(
+        return_value=httpx.Response(200, json={"items": [{"code": "offer1"}], "page_info": {}})
+    )
+    result = await products.offers("abc-123")
+    assert result.items[0].code == "offer1"
+
+
+async def test_plans_uses_ucode_path(products, respx_mock):
+    respx_mock.get(f"{PROD_BASE}/products/abc-123/plans").mock(
+        return_value=httpx.Response(200, json={"items": [{"code": "plan1", "periodicity": "MONTHLY"}], "page_info": {}})
+    )
+    result = await products.plans("abc-123")
+    assert result.items[0].periodicity == "MONTHLY"

--- a/tests/resources/test_async_sales.py
+++ b/tests/resources/test_async_sales.py
@@ -1,0 +1,70 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.models.pagination import PaginatedResponse
+from hotmart.resources.async_sales import AsyncSales
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+BASE = "https://developers.hotmart.com/payments/api/v1"
+
+HISTORY_RESPONSE = {
+    "items": [{"purchase": {"transaction": "HP123", "status": "APPROVED"}, "buyer": {"name": "Paula"}}],
+    "page_info": {"total_results": 1, "results_per_page": 10},
+}
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def sales():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncSales(BaseAsyncClient(config))
+
+
+async def test_history_returns_paginated_response(sales, respx_mock):
+    respx_mock.get(f"{BASE}/sales/history").mock(return_value=httpx.Response(200, json=HISTORY_RESPONSE))
+    result = await sales.history()
+    assert isinstance(result, PaginatedResponse)
+    assert result.items[0].purchase.transaction == "HP123"
+
+
+async def test_history_passes_params(sales, respx_mock):
+    captured: list[httpx.Request] = []
+    def capture(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json=HISTORY_RESPONSE)
+    respx_mock.get(f"{BASE}/sales/history").mock(side_effect=capture)
+    await sales.history(buyer_name="Paula", transaction_status="APPROVED")
+    assert "buyer_name=Paula" in str(captured[0].url)
+    assert "transaction_status=APPROVED" in str(captured[0].url)
+
+
+async def test_history_passes_kwargs(sales, respx_mock):
+    captured: list[httpx.Request] = []
+    def capture(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json=HISTORY_RESPONSE)
+    respx_mock.get(f"{BASE}/sales/history").mock(side_effect=capture)
+    await sales.history(custom_param="val")
+    assert "custom_param=val" in str(captured[0].url)
+
+
+async def test_history_autopaginate_follows_next_page_token(sales, respx_mock):
+    page1 = {"items": [{"purchase": {"transaction": "HP1"}}], "page_info": {"next_page_token": "tok2"}}
+    page2 = {"items": [{"purchase": {"transaction": "HP2"}}], "page_info": {}}
+    respx_mock.get(f"{BASE}/sales/history").mock(side_effect=[
+        httpx.Response(200, json=page1),
+        httpx.Response(200, json=page2),
+    ])
+    items = [item async for item in sales.history_autopaginate()]
+    assert len(items) == 2
+
+
+async def test_refund_calls_put(sales, respx_mock):
+    respx_mock.put(f"{BASE}/sales/HP123/refund").mock(return_value=httpx.Response(200, text="{}"))
+    await sales.refund("HP123")  # no error = success

--- a/tests/resources/test_async_subscriptions.py
+++ b/tests/resources/test_async_subscriptions.py
@@ -1,0 +1,55 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._config import ClientConfig
+from hotmart.resources.async_subscriptions import AsyncSubscriptions
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+BASE = "https://developers.hotmart.com/payments/api/v1"
+
+SUB_ITEM = {"subscriber_code": "ABC1", "status": "ACTIVE", "product": {"id": 1}}
+LIST_RESPONSE = {"items": [SUB_ITEM], "page_info": {"results_per_page": 10}}
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "tok", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def subs():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=0)
+    return AsyncSubscriptions(BaseAsyncClient(config))
+
+
+async def test_list_returns_paginated(subs, respx_mock):
+    respx_mock.get(f"{BASE}/subscriptions").mock(return_value=httpx.Response(200, json=LIST_RESPONSE))
+    result = await subs.list()
+    assert result.items[0].subscriber_code == "ABC1"
+
+
+async def test_purchases_returns_list(subs, respx_mock):
+    data = [{"transaction": "HP1", "status": "APPROVED"}]
+    respx_mock.get(f"{BASE}/subscriptions/ABC1/purchases").mock(return_value=httpx.Response(200, json=data))
+    result = await subs.purchases("ABC1")
+    assert result[0].transaction == "HP1"
+
+
+async def test_cancel_calls_post_with_body(subs, respx_mock):
+    resp = {"success_subscriptions": [{"subscriber_code": "ABC1", "status": "INACTIVE"}], "fail_subscriptions": []}
+    respx_mock.post(f"{BASE}/subscriptions/cancel").mock(return_value=httpx.Response(200, json=resp))
+    result = await subs.cancel(["ABC1"])
+    assert result.success_subscriptions[0].subscriber_code == "ABC1"
+
+
+async def test_change_due_day_calls_patch(subs, respx_mock):
+    respx_mock.patch(f"{BASE}/subscriptions/ABC1").mock(return_value=httpx.Response(200, text="{}"))
+    await subs.change_due_day("ABC1", 15)  # no error = success
+
+
+async def test_reactivate_single_calls_post(subs, respx_mock):
+    resp = {"subscriber_code": "ABC1", "status": "INACTIVE"}
+    respx_mock.post(f"{BASE}/subscriptions/ABC1/reactivate").mock(return_value=httpx.Response(200, json=resp))
+    result = await subs.reactivate_single("ABC1", charge=True)
+    assert result.subscriber_code == "ABC1"

--- a/tests/test_async_auth.py
+++ b/tests/test_async_auth.py
@@ -1,0 +1,74 @@
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from hotmart._async_auth import AsyncTokenManager
+from hotmart._config import ClientConfig
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+
+@pytest.fixture
+def config():
+    return ClientConfig(client_id="cid", client_secret="csec", basic="Basic dGVzdA==")
+
+@pytest.fixture
+def manager(config):
+    return AsyncTokenManager(config)
+
+
+def _token_response(token: str = "tok123", expires_in: int = 86400) -> httpx.Response:
+    return httpx.Response(200, json={"access_token": token, "token_type": "bearer", "expires_in": expires_in})
+
+
+async def test_get_token_fetches_new_token(manager, respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response("tok123"))
+    assert await manager.get_token() == "tok123"
+
+
+async def test_get_token_caches_on_second_call(manager, respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response("tok123"))
+    await manager.get_token()
+    await manager.get_token()
+    assert respx_mock.calls.call_count == 1
+
+
+async def test_get_token_refreshes_expired_token(manager, respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response("new_tok"))
+    manager._token = "old_tok"
+    manager._expires_at = time.time() - 1  # already expired
+    assert await manager.get_token() == "new_tok"
+
+
+async def test_get_token_refreshes_near_expiry(manager, respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response("fresh"))
+    manager._token = "about_to_expire"
+    manager._expires_at = time.time() + 100  # within 300s buffer
+    assert await manager.get_token() == "fresh"
+
+
+async def test_invalidate_forces_refresh(manager, respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response("tok123"))
+    await manager.get_token()
+    await manager.invalidate()
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response("tok456"))
+    assert await manager.get_token() == "tok456"
+
+
+async def test_token_value_not_in_request_headers(manager, respx_mock):
+    """Auth request must use basic, not the token itself."""
+    captured: list[httpx.Request] = []
+    def capture(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return _token_response()
+    respx_mock.post(TOKEN_URL).mock(side_effect=capture)
+    await manager.get_token()
+    assert captured[0].headers["authorization"] == "Basic dGVzdA=="
+
+
+async def test_concurrent_calls_fetch_token_once(manager, respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=_token_response())
+    tokens = await asyncio.gather(*[manager.get_token() for _ in range(10)])
+    assert respx_mock.calls.call_count == 1
+    assert all(tok == tokens[0] for tok in tokens)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,101 @@
+import httpx
+import pytest
+
+from hotmart._async_base_client import BaseAsyncClient
+from hotmart._base_client import _build_params
+from hotmart._config import ClientConfig
+from hotmart._exceptions import AuthenticationError, InternalServerError, RateLimitError
+
+TOKEN_URL = "https://api-sec-vlc.hotmart.com/security/oauth/token"
+BASE = "https://developers.hotmart.com/payments/api/v1"
+
+@pytest.fixture(autouse=True)
+def mock_token(respx_mock):
+    respx_mock.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={
+        "access_token": "test_token", "token_type": "bearer", "expires_in": 86400,
+    }))
+
+@pytest.fixture
+def client():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic dGVzdA==", max_retries=0)
+    return BaseAsyncClient(config)
+
+
+def test_build_params_drops_none():
+    result = _build_params({"self": None, "a": 1, "b": None, "c": "x"})
+    assert result == {"a": 1, "c": "x"}
+
+def test_build_params_merges_kwargs():
+    result = _build_params({"self": None, "a": 1, "kwargs": {"extra": "val"}})
+    assert result == {"a": 1, "extra": "val"}
+
+async def test_get_returns_deserialized_model(client, respx_mock):
+    from pydantic import BaseModel
+    class MyModel(BaseModel):
+        foo: str
+
+    respx_mock.get(f"{BASE}/test").mock(return_value=httpx.Response(200, json={"foo": "bar"}))
+    result = await client._get("/test", cast_to=MyModel)
+    assert result.foo == "bar"
+
+async def test_get_returns_none_for_empty_response(client, respx_mock):
+    respx_mock.get(f"{BASE}/test").mock(return_value=httpx.Response(200, text="{}"))
+    result = await client._get("/test")
+    assert result is None
+
+async def test_raises_authentication_error_on_403(client, respx_mock):
+    respx_mock.get(f"{BASE}/test").mock(return_value=httpx.Response(403))
+    with pytest.raises(AuthenticationError):
+        await client._get("/test")
+
+async def test_raises_rate_limit_on_429(client, respx_mock):
+    respx_mock.get(f"{BASE}/test").mock(return_value=httpx.Response(429, headers={"RateLimit-Reset": "1"}))
+    with pytest.raises(RateLimitError):
+        await client._get("/test")
+
+async def test_raises_internal_server_error_on_500(client, respx_mock):
+    respx_mock.get(f"{BASE}/test").mock(return_value=httpx.Response(500))
+    with pytest.raises(InternalServerError):
+        await client._get("/test")
+
+async def test_retries_on_500_then_succeeds(respx_mock):
+    from pydantic import BaseModel
+    class M(BaseModel):
+        ok: bool
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", max_retries=2)
+    client = BaseAsyncClient(config)
+    respx_mock.get(f"{BASE}/test").mock(side_effect=[
+        httpx.Response(500),
+        httpx.Response(200, json={"ok": True}),
+    ])
+    result = await client._get("/test", cast_to=M)
+    assert result.ok is True
+
+async def test_401_triggers_token_refresh_and_retries(client, respx_mock):
+    from pydantic import BaseModel
+    class M(BaseModel):
+        val: int
+    respx_mock.get(f"{BASE}/test").mock(side_effect=[
+        httpx.Response(401),
+        httpx.Response(200, json={"val": 42}),
+    ])
+    result = await client._get("/test", cast_to=M)
+    assert result.val == 42
+
+async def test_context_manager_closes_client():
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x")
+    async with BaseAsyncClient(config) as c:
+        assert not c._http.is_closed
+    assert c._http.is_closed
+
+async def test_uses_sandbox_url(respx_mock):
+    from pydantic import BaseModel
+    class M(BaseModel):
+        x: int
+    respx_mock.get("https://sandbox.hotmart.com/payments/api/v1/test").mock(
+        return_value=httpx.Response(200, json={"x": 1})
+    )
+    config = ClientConfig(client_id="cid", client_secret="csec", basic="Basic x", sandbox=True, max_retries=0)
+    c = BaseAsyncClient(config)
+    result = await c._get("/test", cast_to=M)
+    assert result.x == 1

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -1,0 +1,224 @@
+"""
+Testes de integração assíncronos contra a API real da Hotmart.
+
+Executar:
+    uv run pytest tests/test_async_integration.py -v
+
+Requer variáveis de ambiente (ou arquivo .env lido manualmente):
+    HOTMART_CLIENT_ID
+    HOTMART_CLIENT_SECRET
+    HOTMART_BASIC
+
+Os testes são automaticamente pulados se as variáveis não estiverem definidas.
+Respostas vazias (sem dados) são aceitas — o que importa é a estrutura retornada.
+"""
+import os
+
+import pytest
+
+from hotmart import AsyncHotmart
+from hotmart._exceptions import HotmartError
+from hotmart.models.pagination import PaginatedResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _creds() -> tuple[str, str, str] | None:
+    cid = os.getenv("HOTMART_CLIENT_ID")
+    secret = os.getenv("HOTMART_CLIENT_SECRET")
+    basic = os.getenv("HOTMART_BASIC")
+    if not (cid and secret and basic):
+        return None
+    return cid, secret, basic
+
+
+def _skip_if_no_creds():
+    if _creds() is None:
+        pytest.skip("Credenciais não configuradas (HOTMART_CLIENT_ID / HOTMART_CLIENT_SECRET / HOTMART_BASIC)")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+async def live_client():
+    _skip_if_no_creds()
+    cid, secret, basic = _creds()  # type: ignore[misc]
+    async with AsyncHotmart(client_id=cid, client_secret=secret, basic=basic) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    async def test_obtém_token(self, live_client):
+        token = await live_client._token_manager.get_token()
+        assert isinstance(token, str)
+        assert len(token) > 10
+
+    async def test_token_é_cacheado(self, live_client):
+        t1 = await live_client._token_manager.get_token()
+        t2 = await live_client._token_manager.get_token()
+        assert t1 == t2
+
+
+# ---------------------------------------------------------------------------
+# Sales
+# ---------------------------------------------------------------------------
+
+class TestSales:
+    async def test_history_retorna_paginado(self, live_client):
+        result = await live_client.sales.history()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_history_items_têm_campos_esperados(self, live_client):
+        result = await live_client.sales.history()
+        for item in result.items:
+            assert hasattr(item, "transaction")
+            assert hasattr(item, "purchase")
+
+    async def test_summary_retorna_paginado(self, live_client):
+        result = await live_client.sales.summary()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_participants_retorna_paginado(self, live_client):
+        result = await live_client.sales.participants()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_commissions_retorna_paginado(self, live_client):
+        result = await live_client.sales.commissions()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_price_details_retorna_paginado(self, live_client):
+        result = await live_client.sales.price_details()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_history_com_max_results(self, live_client):
+        result = await live_client.sales.history(max_results=5)
+        assert isinstance(result, PaginatedResponse)
+        assert len(result.items) <= 5
+
+    async def test_history_page_info_presente_se_há_dados(self, live_client):
+        result = await live_client.sales.history()
+        if result.items:
+            assert result.page_info is not None
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions
+# ---------------------------------------------------------------------------
+
+class TestSubscriptions:
+    async def test_list_retorna_paginado(self, live_client):
+        result = await live_client.subscriptions.list()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_list_items_têm_campos_esperados(self, live_client):
+        result = await live_client.subscriptions.list()
+        for item in result.items:
+            assert hasattr(item, "subscriber_code")
+            assert hasattr(item, "status")
+
+    async def test_summary_retorna_paginado(self, live_client):
+        result = await live_client.subscriptions.summary()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_list_filtra_por_status(self, live_client):
+        result = await live_client.subscriptions.list(status="ACTIVE")
+        assert isinstance(result, PaginatedResponse)
+        for item in result.items:
+            assert item.status == "ACTIVE"
+
+    async def test_purchases_requer_subscriber_code(self, live_client):
+        result = await live_client.subscriptions.list()
+        if not result.items:
+            pytest.skip("Sem assinaturas para testar purchases")
+        code = result.items[0].subscriber_code
+        purchases = await live_client.subscriptions.purchases(subscriber_code=code)
+        assert isinstance(purchases, PaginatedResponse)
+
+    async def test_transactions_requer_subscriber_code(self, live_client):
+        result = await live_client.subscriptions.list()
+        if not result.items:
+            pytest.skip("Sem assinaturas para testar transactions")
+        code = result.items[0].subscriber_code
+        txs = await live_client.subscriptions.transactions(subscriber_code=code)
+        assert isinstance(txs, PaginatedResponse)
+
+
+# ---------------------------------------------------------------------------
+# Products
+# ---------------------------------------------------------------------------
+
+class TestProducts:
+    async def test_list_retorna_paginado(self, live_client):
+        result = await live_client.products.list()
+        assert isinstance(result, PaginatedResponse)
+
+    async def test_list_items_têm_campos_esperados(self, live_client):
+        result = await live_client.products.list()
+        for item in result.items:
+            assert hasattr(item, "ucode")
+            assert hasattr(item, "name")
+
+    async def test_offers_requer_ucode(self, live_client):
+        result = await live_client.products.list()
+        if not result.items:
+            pytest.skip("Sem produtos para testar offers")
+        ucode = result.items[0].ucode
+        offers = await live_client.products.offers(ucode=ucode)
+        assert isinstance(offers, PaginatedResponse)
+
+    async def test_plans_requer_ucode(self, live_client):
+        result = await live_client.products.list()
+        if not result.items:
+            pytest.skip("Sem produtos para testar plans")
+        ucode = result.items[0].ucode
+        from hotmart._exceptions import BadRequestError
+        try:
+            plans = await live_client.products.plans(ucode=ucode)
+            assert isinstance(plans, PaginatedResponse)
+        except BadRequestError:
+            pytest.xfail("Hotmart bug: /products/{ucode}/plans retorna 400 para produtos sem planos")
+
+
+# ---------------------------------------------------------------------------
+# Coupons
+# ---------------------------------------------------------------------------
+
+class TestCoupons:
+    async def test_list_retorna_paginado(self, live_client):
+        products = await live_client.products.list()
+        if not products.items:
+            pytest.skip("Sem produtos para testar coupons")
+        ucode = products.items[0].ucode
+        result = await live_client.coupons.list(product_id=ucode)
+        assert isinstance(result, PaginatedResponse)
+
+
+# ---------------------------------------------------------------------------
+# Smoke — todos os endpoints retornam sem exceção
+# ---------------------------------------------------------------------------
+
+class TestSmoke:
+    """Garante que nenhum endpoint assíncrono lança exceção inesperada."""
+
+    @pytest.mark.parametrize("call", [
+        lambda c: c.sales.history(),
+        lambda c: c.sales.summary(),
+        lambda c: c.sales.participants(),
+        lambda c: c.sales.commissions(),
+        lambda c: c.sales.price_details(),
+        lambda c: c.subscriptions.list(),
+        lambda c: c.subscriptions.summary(),
+        lambda c: c.products.list(),
+    ])
+    async def test_endpoint_não_lança_exceção(self, live_client, call):
+        try:
+            await call(live_client)
+        except HotmartError as e:
+            pytest.fail(f"HotmartError inesperado: {e}")

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -42,7 +42,7 @@ def _skip_if_no_creds():
 # Fixtures
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 async def live_client():
     _skip_if_no_creds()
     cid, secret, basic = _creds()  # type: ignore[misc]

--- a/tests/test_async_rate_limit.py
+++ b/tests/test_async_rate_limit.py
@@ -1,0 +1,37 @@
+import time
+
+import httpx
+
+from hotmart._async_rate_limit import AsyncRateLimitTracker
+
+
+async def test_update_reads_remaining_header():
+    tracker = AsyncRateLimitTracker()
+    await tracker.update(httpx.Headers({"RateLimit-Remaining": "42", "RateLimit-Reset": "60"}))
+    assert tracker._remaining == 42
+
+
+async def test_wait_if_needed_does_not_sleep_when_remaining_positive():
+    tracker = AsyncRateLimitTracker()
+    tracker._remaining = 10
+    start = time.monotonic()
+    await tracker.wait_if_needed()
+    assert time.monotonic() - start < 0.1
+
+
+async def test_wait_if_needed_sleeps_when_remaining_zero(monkeypatch):
+    slept: list[float] = []
+    async def fake_sleep(s: float) -> None:
+        slept.append(s)
+    monkeypatch.setattr("hotmart._async_rate_limit.asyncio.sleep", fake_sleep)
+    tracker = AsyncRateLimitTracker()
+    tracker._remaining = 0
+    tracker._reset_at = time.time() + 2.0
+    await tracker.wait_if_needed()
+    assert slept and slept[0] > 0
+
+
+async def test_update_ignores_missing_headers():
+    tracker = AsyncRateLimitTracker()
+    await tracker.update(httpx.Headers({}))
+    assert tracker._remaining == 500  # default unchanged

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "hotmart-python"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -164,6 +164,7 @@ dev = [
     { name = "coverage" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "respx" },
     { name = "ruff" },
 ]
@@ -179,6 +180,7 @@ dev = [
     { name = "coverage", specifier = ">=7.0" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.4" },
 ]
@@ -512,6 +514,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "hotmart-python"
-version = "1.0.4"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Closes #17.

- Adds `AsyncHotmart` client alongside the existing sync `Hotmart` — **zero breaking changes** to existing API
- Independent parallel implementation using `httpx.AsyncClient`, `asyncio.Lock`, and native `async/await` throughout
- All 7 async resource groups (`sales`, `subscriptions`, `products`, `coupons`, `club`, `events`, `negotiation`) with full feature parity including `AsyncIterator`-based autopagination
- Reuses existing sync-safe modules (`_config`, `_exceptions`, `_logging`, `_retry`, `models/`) — no duplication of pure logic

## New files (11 source + 11 test)

| Layer | Files |
|---|---|
| Auth & rate limit | `_async_auth.py`, `_async_rate_limit.py` |
| HTTP engine | `_async_base_client.py` |
| Resource base | `resources/_async_base.py` |
| Resources (7) | `resources/async_sales.py`, `async_subscriptions.py`, `async_products.py`, `async_coupons.py`, `async_club.py`, `async_events.py`, `async_negotiation.py` |
| Client | `_async_client.py` |
| Tests | 10 unit test files + `test_async_integration.py` |

## Usage

```python
from hotmart import AsyncHotmart

async with AsyncHotmart(client_id="...", client_secret="...", basic="...") as client:
    sales = await client.sales.history()
    async for sub in client.subscriptions.list_autopaginate():
        print(sub)
```

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy --strict src/hotmart/` — passes (pre-existing sync issues untouched)
- [x] 111 unit tests pass (67 sync + 44 async)
- [x] 25 sync integration tests pass against real Hotmart API
- [x] 24 async integration tests pass against real Hotmart API
- [x] Concurrent `asyncio.gather` with 3 simultaneous requests verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)